### PR TITLE
Fix occasional SEGV on window close

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -237,8 +237,8 @@ struct App<M> {
 }
 
 struct State {
-    window: Arc<Window>,
     pixels: Pixels<'static>,
+    window: Arc<Window>,
 }
 
 impl<M: Memory> ApplicationHandler for App<M> {
@@ -286,6 +286,8 @@ impl<M: Memory> ApplicationHandler for App<M> {
         self.input.end_step();
 
         if self.input.close_requested() || self.input.destroyed() {
+            // Drop GPU/surface resources while the event loop is still alive.
+            self.state = None;
             event_loop.exit();
             return;
         }


### PR DESCRIPTION
Every now and then the emulator crashes with a SEGV when the window is closed. 

I am unsure, but I think this is because of the drop-order in the frontend, since it consistently crashed inside `libwayland/libEGL`. While I am aware that may be a Wayland/Linux issue, I believe that handling the shutdown explicitly (`self.state = None;`) and keeping the window alive longer than potential draw calls can come in (field order) would still be best practice. I could not reproduce the Segfault after this change. Before it would appear about once in 100 runs (so not a big deal either).